### PR TITLE
Hardcode a workaround to ignore merge commits.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbCause.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbCause.java
@@ -53,7 +53,12 @@ public class GhprbCause extends Cause{
 	}
 	
 	public boolean isMerged() {
-		return merged;
+        // hardcode hack: never automatically merge a commit for a pull request build.
+        // see various bugs that are affected by this. Header descriptions for edx are in
+        // https://openedx.atlassian.net/browse/TE-703
+
+        //return merged;
+        return false;
 	}
 
 	public int getPullID(){

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
@@ -152,6 +152,8 @@ public class GhprbTrigger extends Trigger<AbstractProject<?, ?>> {
 
     public QueueTaskFuture<?> startJob(GhprbCause cause, GhprbRepository repo) {
         ArrayList<ParameterValue> values = getDefaultParameters();
+        // Note that the below line is hardcoded to always execute one path from the or statement.
+        // @link GhprbCause.isMerged
         final String commitSha = cause.isMerged() ? "origin/pr/" + cause.getPullID() + "/merge" : cause.getCommit();
         values.add(new StringParameterValue("sha1", commitSha));
         values.add(new StringParameterValue("ghprbActualCommit", cause.getCommit()));


### PR DESCRIPTION
Issue 116 in the janinko fork
